### PR TITLE
Preserve Opacity of WMS layers in Printing

### DIFF
--- a/php/print_util.php
+++ b/php/print_util.php
@@ -212,7 +212,7 @@ function renderImage($mapbook, $layers_json,  $mapImageWidth, $mapImageHeight, $
 	for($i = 0; $i < sizeof($layers_json); $i++) {
 		$layer = $layers_json[$i];
 		$image = null;
-		$opacity = 100.0;
+		$opacity = $layers_json[$i]["opacity"]*100;
 
 		if($layer["type"] == 'wms') {
 			#echo "<br>WMS LAyer";


### PR DESCRIPTION
For some reason all WMS layers were being forced to Opaciy = 100.

This fix addresses this long ago reported issue:
https://lists.osgeo.org/pipermail/geomoose-users/2011-November/003522.html

Which was reported in trac here:
http://trac.osgeo.org/geomoose/ticket/127

But which apparently never became a GitHub issue?